### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.fastapi-app
+++ b/Dockerfile.fastapi-app
@@ -1,0 +1,21 @@
+FROM python:3.9-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project
+COPY . /app/
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Run the application
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO test_project
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: test_project
+
+fastapi-app:
+  defines: runnable
+  metadata:
+    name: fastapi-app
+    description: A FastAPI web application with a callback endpoint for logging JSON data.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    fastapi-app:
+      image: env-4363.registry.local/fastapi-app:main-0a85926
+      build: .
+      dockerfile: Dockerfile.fastapi-app
+  services:
+    fastapi-default:
+      description: Default port for FastAPI application
+      container: fastapi-app
+      port: 8000
+      host-port: 8000
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - test_project/fastapi-app


### PR DESCRIPTION
# Containerization and Deployment Configuration for FastAPI Application

## Summary of Changes
- **Dockerfile Creation**: I created a `Dockerfile.fastapi-app` to containerize the FastAPI web application. This Dockerfile is configured to install all necessary dependencies listed in `requirements.txt`, expose port 8000, and run the application using Uvicorn.
- **Monk.io Configuration**: Added a `monk.yaml` file to define the Monk.io deployment configuration and a `MANIFEST` file to list all files containing Monk configurations.
- **Service Analysis**: Confirmed that the FastAPI application does not require any external services like databases and does not use any specific environment variables for its functionality. The application is self-contained with a single service exposing a POST endpoint for logging JSON data.

## Instructions for Deployment
- **Merge PR**: To deploy the application, simply merge this PR. The application will be re-deployed on each subsequent push.
- **Service Port**: Ensure that port 8000 is available for the FastAPI application to receive requests.

## Notes on Completion
The containerization and deployment configuration process is complete. The FastAPI service is running successfully in isolation, and no further actions are required at this point. The application is ready for deployment and does not require any additional environment variables or service connections.